### PR TITLE
Add conda activation and deactivation scripts for XKB_CONFIG_ROOT

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Set XKB_CONFIG_ROOT for Zed when this conda env is active (Linux only)
+if [ "$(uname)" = "Linux" ]; then
+  export CONDA_ZED_XKB_CONFIG_ROOT_BACKUP="${XKB_CONFIG_ROOT-}"
+  export XKB_CONFIG_ROOT="/usr/share/X11/xkb"
+fi
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,5 +50,10 @@ else
     install -m0755 target/${CARGO_BUILD_TARGET}/release/cli "${PREFIX}/bin/zed"
 fi
 
+# Install conda activation scripts to set runtime env vars
+mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
+install -m0755 "${RECIPE_DIR}/activate.sh" "${PREFIX}/etc/conda/activate.d/zed_activate.sh"
+install -m0755 "${RECIPE_DIR}/deactivate.sh" "${PREFIX}/etc/conda/deactivate.d/zed_deactivate.sh"
+
 # Remove target dir to save disk space
 rm -rf target

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Restore previous XKB_CONFIG_ROOT when deactivating this conda env (Linux only)
+if [ "$(uname)" = "Linux" ]; then
+  if [ -n "${CONDA_ZED_XKB_CONFIG_ROOT_BACKUP-}" ]; then
+    export XKB_CONFIG_ROOT="${CONDA_ZED_XKB_CONFIG_ROOT_BACKUP}"
+  else
+    unset XKB_CONFIG_ROOT
+  fi
+  unset CONDA_ZED_XKB_CONFIG_ROOT_BACKUP
+fi
+

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 38cdaf9636f0d3133d1b4603eed3ead85f8382492befc0e14ef0b66f03bfb89d
 
 build:
-  number: 1
+  number: 2
   skip:
     - win
 


### PR DESCRIPTION
With the newest version of Zed, if xkbcommon can't find the folder Zed crashes when attempting to start

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
