### PR TITLE
remove default `"activate": true` from shortcut definition

### DIFF
--- a/recipe/menu.json
+++ b/recipe/menu.json
@@ -5,7 +5,6 @@
     {
       "name": "Zed",
       "description": "High-performance, multiplayer code editor",
-      "activate": true,
       "icon": "{{ MENU_DIR }}/zed.{{ ICON_EXT }}",
       "command": [""],
       "platforms": {

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
     sha256: d2aef999224c3803fb4084d58f42d4b15bcccc8ea2fe9b4462ae57d3f48e7f13
 
 build:
-  number: 3
+  number: 4
   skip:
     - win
 


### PR DESCRIPTION
we may want to wait to merge this until https://github.com/conda/rattler/pull/1678 has landed in Pixi
